### PR TITLE
Update exiv2 to 0.28.3

### DIFF
--- a/io.github.dfandrich.gpscorrelate.json
+++ b/io.github.dfandrich.gpscorrelate.json
@@ -36,8 +36,8 @@
           "sources": [
               {
                   "type": "archive",
-                  "url": "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.2.tar.gz",
-                  "sha256": "543bead934135f20f438e0b6d8858c55c5fcb7ff80f5d1d55489965f1aad58b9"
+                  "url": "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.3.tar.gz",
+                  "sha256": "1315e17d454bf4da3cc0edb857b1d2c143670f3485b537d0f946d9ed31d87b70"
               }
           ]
         },


### PR DESCRIPTION
This fixes a low-security vulnerability CVE-2024-39695